### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@
 # It runs on pushes to the main branch and on pull requests.
 
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SaiSivarajuIN/ai_think/security/code-scanning/1](https://github.com/SaiSivarajuIN/ai_think/security/code-scanning/1)

To fix the problem, add a `permissions` key to the workflow or the specific job. Since the job shown is only reading the repository contents (for checkout, setup, running scripts), the minimal required permission is `contents: read`. The best fix is to add the block:

```yaml
permissions:
  contents: read
```

immediately after the workflow name (line 4), so it applies to the entire workflow unless any job needs broader permissions. Alternatively, you can add it within any job's block if you wish to scope permissions even more narrowly, but as there is only one job here, placing it at the root is cleaner and clearer.

No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
