### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -89,6 +89,7 @@
             simpleLineBreaks: true,
             openLinksInNewWindow: true,
             emoji: true,
+            sanitize: true // Prevent interpretation of raw HTML in Markdown
         });
 
         // Render markdown for assistant messages


### PR DESCRIPTION
Potential fix for [https://github.com/SaiSivarajuIN/ai_think/security/code-scanning/18](https://github.com/SaiSivarajuIN/ai_think/security/code-scanning/18)

To fix this issue, we need to ensure that any user-controlled content extracted from the DOM (via `textContent`, `.dataset`, etc.) is properly escaped before being reinterpreted as HTML with `innerHTML`. Since the content is being rendered to HTML via Showdown, we should enable Showdown's options to escape or discard any injected HTML tags (by disabling raw HTML in Markdown).

Specifically, Showdown provides the `sanitize` option, which disables raw HTML input and results in escaped output. By setting `sanitize: true` in the Showdown converter options, unsafe raw HTML will be escaped, mitigating XSS. This change should be made in the region where the converter is instantiated, in `templates/history.html`, lines ~83-93.

No further changes are needed, as this option will safely process all Markdown input and render only safe HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
