### PR TITLE
Potential fix for code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,19 @@
+// Simple HTML escape utility
+function escapeHTML(str) {
+    return str.replace(/[&<>"'`=\/]/g, function(s) {
+        return ({
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&#39;",
+            '/': "&#x2F;",
+            "`": "&#x60;",
+            "=": "&#x3D;"
+        })[s];
+    });
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     const chatbox = document.getElementById('chatbox');
     const userInput = document.getElementById('userMessage');
@@ -816,7 +832,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     const contentElement = thoughtDiv.querySelector('div');
                     if (headingElement && contentElement) {
                         const headingText = headingElement.innerText;
-                        headingElement.outerHTML = `<p class="section-heading">${headingText}</p>`;
+                        headingElement.outerHTML = `<p class="section-heading">${escapeHTML(headingText)}</p>`;
                         
                         if (headingText.toLowerCase().includes('thought process')) {
                             contentElement.outerHTML = `<table class="thought-table"><tr><td>${contentElement.innerHTML}</td></tr></table>`;


### PR DESCRIPTION
Potential fix for [https://github.com/SaiSivarajuIN/ai_think/security/code-scanning/24](https://github.com/SaiSivarajuIN/ai_think/security/code-scanning/24)

The best way to fix this problem is to ensure that any data inserted into an HTML template (using `${...}`) is always properly escaped for HTML meta-characters. For this, we need to encode the text so that any potentially dangerous characters are serialized as harmless entities (like `<` as `&lt;`, `'` as `&#39;`, etc.). This prevents malicious content from being executed or altering the document structure.

- Edit static/script.js at line 819, replacing the direct interpolation of `headingText` with its HTML-escaped equivalent.
- Write a utility function in static/script.js to escape HTML (e.g., escapeHTML).
- Replace `${headingText}` with `${escapeHTML(headingText)}` in the template string.
- No outside dependencies are needed; a simple escape function can be written inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
